### PR TITLE
Update KDE Connect formula to latest nightly build (2025-07-15)

### DIFF
--- a/Formula/kdeconnect.rb
+++ b/Formula/kdeconnect.rb
@@ -1,7 +1,7 @@
 class Kdeconnect < Formula
   desc "Connect your phone to your computer"
   homepage "https://kdeconnect.kde.org/"
-  version "0.0.0"
+  version "0.20250715"
   license "GPL-2.0-or-later"
 
   livecheck do
@@ -10,9 +10,9 @@ class Kdeconnect < Formula
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-arm64/kdeconnect-kde-master-latest-macos-clang-arm64.dmg"
+      url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-arm64/kdeconnect-kde-master-5215-macos-clang-arm64.dmg"
     else
-      url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-x86_64/kdeconnect-kde-master-latest-macos-clang-x86_64.dmg"
+      url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-x86_64/kdeconnect-kde-master-5215-macos-clang-x86_64.dmg"
     end
   end
 


### PR DESCRIPTION
This automated PR updates the KDE Connect formula to use the latest nightly build.

  - Updated revision to force brew to fetch the latest DMG files
  - Date: 2025-07-15