### PR TITLE
Update KDE Connect to version 5218

### DIFF
--- a/Formula/kdeconnect.rb
+++ b/Formula/kdeconnect.rb
@@ -1,7 +1,7 @@
 class Kdeconnect < Formula
   desc "Connect your phone to your computer"
   homepage "https://kdeconnect.kde.org/"
-  version "0"
+  version "5218"
   license "GPL-2.0-or-later"
 
   livecheck do
@@ -12,9 +12,9 @@ class Kdeconnect < Formula
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-arm64/kdeconnect-kde-master-#{version}-macos-clang-arm64.dmg"
+    url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-arm64/kdeconnect-kde-master-5218-macos-clang-arm64.dmg"
     else
-      url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-x86_64/kdeconnect-kde-master-#{version}-macos-clang-x86_64.dmg"
+    url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-x86_64/kdeconnect-kde-master-5218-macos-clang-x86_64.dmg"
     end
   end
 


### PR DESCRIPTION
This automated PR updates the KDE Connect formula to version 5218.

  - Updated via Homebrew livecheck
  - Version: 5218

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application to version 5218, including new download links for macOS ARM64 and x86_64 installers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->