### PR TITLE
Update KDE Connect to version 5218

### DIFF
--- a/Casks/kdeconnect.rb
+++ b/Casks/kdeconnect.rb
@@ -1,7 +1,7 @@
 cask "kdeconnect" do
   desc "Connect your phone to your computer"
   homepage "https://kdeconnect.kde.org/"
-  version "0"
+  version "5218"
   license "GPL-2.0-or-later"
 
   livecheck do
@@ -12,9 +12,9 @@ cask "kdeconnect" do
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-arm64/kdeconnect-kde-master-#{version}-macos-clang-arm64.dmg"
+    url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-arm64/kdeconnect-kde-master-5218-macos-clang-arm64.dmg"
     else
-      url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-x86_64/kdeconnect-kde-master-#{version}-macos-clang-x86_64.dmg"
+    url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-x86_64/kdeconnect-kde-master-5218-macos-clang-x86_64.dmg"
     end
   end
 


### PR DESCRIPTION
This automated PR updates the KDE Connect cask to version 5218.

  - Updated via Homebrew livecheck
  - Version: 5218

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated kdeconnect to version 5218 with new download links for macOS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->