### PR TITLE
Update KDE Connect to version 5218

### DIFF
--- a/Casks/kdeconnect.rb
+++ b/Casks/kdeconnect.rb
@@ -2,7 +2,7 @@ cask "kdeconnect" do
   name "KDE Connect"
   desc "Connect your phone to your computer"
   homepage "https://kdeconnect.kde.org/"
-  version "0"
+  version "5218"
 
   livecheck do
     url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-arm64/"
@@ -16,7 +16,7 @@ cask "kdeconnect" do
       sha256 "35eef0facd814f3503de43e935ae650f1616a0c0d7b39b7821ad1f1c83373063"
     else
       url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-x86_64/kdeconnect-kde-master-5218-macos-clang-x86_64.dmg"
-      sha256 "35eef0facd814f3503de43e935ae650f1616a0c0d7b39b7821ad1f1c83373063"
+      sha256 "2708e6d6d13dca7104f5d5f4ddd6ce8736d714ad00e03253b55b9c56e1a265a4"
     end
   end
 


### PR DESCRIPTION
This automated PR updates the KDE Connect cask to version 5218.

  - Updated via Homebrew livecheck
  - Version: 5218