### PR TITLE
Update KDE Connect to version 5218

### DIFF
--- a/Casks/kdeconnect.rb
+++ b/Casks/kdeconnect.rb
@@ -2,7 +2,7 @@ cask "kdeconnect" do
   name "KDE Connect"
   desc "Connect your phone to your computer"
   homepage "https://kdeconnect.kde.org/"
-  version "0"
+  version "5218"
 
   livecheck do
     url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-arm64/"


### PR DESCRIPTION
This automated PR updates the KDE Connect cask to version 5218.

  - Updated via Homebrew livecheck
  - Version: 5218