### PR TITLE
Update KDE Connect to version 5333

### DIFF
--- a/Casks/kdeconnect.rb
+++ b/Casks/kdeconnect.rb
@@ -2,7 +2,7 @@ cask "kdeconnect" do
   name "KDE Connect"
   desc "Enabling communication between all your devices"
   homepage "https://kdeconnect.kde.org/"
-  version "5331"
+  version "5333"
 
   livecheck do
     url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-arm64/"
@@ -12,10 +12,10 @@ cask "kdeconnect" do
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-arm64/kdeconnect-kde-master-5331-macos-clang-arm64.dmg"
+      url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-arm64/kdeconnect-kde-master-5333-macos-clang-arm64.dmg"
       sha256 :no_check
     else
-      url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-x86_64/kdeconnect-kde-master-5331-macos-clang-x86_64.dmg"
+      url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-x86_64/kdeconnect-kde-master-5333-macos-clang-x86_64.dmg"
       sha256 :no_check
     end
   end


### PR DESCRIPTION
This automated PR updates the KDE Connect cask to version 5333.

  - Updated via Homebrew livecheck
  - Version: 5333