### PR TITLE
Fix deprecated depends_on macos string comparison

### DIFF
--- a/Casks/kdeconnect.rb
+++ b/Casks/kdeconnect.rb
@@ -10,7 +10,7 @@ cask "kdeconnect" do
     strategy :page_match
   end
 
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
 
   on_macos do
     if Hardware::CPU.arm?


### PR DESCRIPTION
## What

Replace the deprecated string comparison form on `Casks/kdeconnect.rb:13`:

```diff
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
```

## Why

`brew update` emits:

> Warning: Calling string comparison format for \`depends_on macos:\` is deprecated! Use \`depends_on macos: :ventura\` instead.

The symbol form already means "this version or newer", so the behavior is unchanged.

Closes #118