### PR TITLE
Refactor cask to idiomatic style and simplify update workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,10 @@ jobs:
           mkdir -p "$(brew --repo)/Library/Taps/testuser"
           cp -r . "$(brew --repo)/Library/Taps/testuser/homebrew-kdeconnect"
 
+      - name: Test cask style
+        run: |
+          brew style testuser/kdeconnect/kdeconnect
+
       - name: Test cask syntax
         run: |
           brew audit --quiet --online --cask testuser/kdeconnect/kdeconnect

--- a/.github/workflows/update-cask.yml
+++ b/.github/workflows/update-cask.yml
@@ -73,27 +73,11 @@ jobs:
       - name: Update cask
         if: steps.check.outputs.update_needed == 'true'
         run: |
-          # Get the actual URLs from the check step
-          ARM64_URL="${{ steps.check.outputs.arm64_url }}"
-          X86_URL="${{ steps.check.outputs.x86_url }}"
           NEW_VERSION="${{ steps.check.outputs.new_version }}"
-          
-          echo "Updating cask with:"
-          echo "  ARM64 URL: $ARM64_URL"
-          echo "  x86_64 URL: $X86_URL"
-          echo "  Version: $NEW_VERSION"
-          
-          # Update ARM64 URL - escape the URL for sed
-          ARM64_URL_ESCAPED=$(echo "$ARM64_URL" | sed 's/[[\.*^$()+?{|]/\\&/g')
-          # Replace the entire ARM64 URL line with the new URL
-          sed -i "/url \".*arm64.*dmg\"/c\      url \"$ARM64_URL_ESCAPED\"" Casks/kdeconnect.rb
-          
-          # Update x86_64 URL - escape the URL for sed
-          X86_URL_ESCAPED=$(echo "$X86_URL" | sed 's/[[\.*^$()+?{|]/\\&/g')
-          # Replace the entire x86_64 URL line with the new URL
-          sed -i "/url \".*x86_64.*dmg\"/c\      url \"$X86_URL_ESCAPED\"" Casks/kdeconnect.rb
-          
-          # Update version
+
+          echo "Updating cask to version: $NEW_VERSION"
+
+          # The DMG URLs interpolate #{version}, so only the version stanza needs bumping.
           sed -i "s|version \"[0-9]*\"|version \"$NEW_VERSION\"|" Casks/kdeconnect.rb
 
       - name: Create Pull Request

--- a/Casks/kdeconnect.rb
+++ b/Casks/kdeconnect.rb
@@ -1,8 +1,17 @@
 cask "kdeconnect" do
+  version "6325"
+  sha256 :no_check
+
+  on_arm do
+    url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-arm64/kdeconnect-kde-master-#{version}-macos-clang-arm64.dmg"
+  end
+  on_intel do
+    url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-x86_64/kdeconnect-kde-master-#{version}-macos-clang-x86_64.dmg"
+  end
+
   name "KDE Connect"
   desc "Enabling communication between all your devices"
   homepage "https://kdeconnect.kde.org/"
-  version "6325"
 
   livecheck do
     url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-arm64/"
@@ -12,25 +21,15 @@ cask "kdeconnect" do
 
   depends_on macos: :ventura
 
-  on_macos do
-    if Hardware::CPU.arm?
-      url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-arm64/kdeconnect-kde-master-6325-macos-clang-arm64.dmg"
-      sha256 :no_check
-    else
-      url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-x86_64/kdeconnect-kde-master-6325-macos-clang-x86_64.dmg"
-      sha256 :no_check
-    end
-  end
-
   app "KDE Connect.app"
 
   zap trash: [
     "~/Library/Application Support/kdeconnect.app",
     "~/Library/Application Support/kpeoplevcard/kdeconnect-*",
-    "~/Library/Preferences/org.kde.kdeconnect.plist",
-    "~/Library/Preferences/kdeconnect",
     "~/Library/Caches/kdeconnect",
     "~/Library/Logs/kdeconnect",
-    "~/Library/Saved Application State/org.kde.kdeconnect.savedState"
+    "~/Library/Preferences/kdeconnect",
+    "~/Library/Preferences/org.kde.kdeconnect.plist",
+    "~/Library/Saved Application State/org.kde.kdeconnect.savedState",
   ]
 end


### PR DESCRIPTION
## Why

`brew style Casks/kdeconnect.rb` reported 10 style offenses (the tap's CI only runs `brew audit`, not `brew style`, so they went unnoticed). This makes the cask idiomatic and, in the process, makes the daily auto-updater simpler and more robust.

## Cask changes (`Casks/kdeconnect.rb`)

- Reorder stanzas to Homebrew's canonical order — `version`/`sha256` first
- Replace `on_macos` + `Hardware::CPU.arm?` with `on_arm` / `on_intel` blocks
- Hoist `sha256 :no_check` to a single top-level stanza (was duplicated in both branches)
- **Interpolate `#{version}` into the DMG URLs** — the build number now lives in exactly one place
- Alphabetize the `zap trash` list and add a trailing comma

## Workflow changes

- **`update-cask.yml`**: since the URLs interpolate `#{version}`, only the `version` stanza needs bumping. Dropped the two fragile per-arch URL `sed` rewrites — a version bump now propagates to both arches automatically.
- **`test.yml`**: added a `brew style` step so future style regressions fail CI.

## Verification

- `brew style Casks/kdeconnect.rb` → **no offenses**
- Simulated a version bump (`6325` → test value): only the `version` line changes and both URLs resolve correctly via interpolation

No functional change to what gets installed — same DMGs, same version scheme.