### PR TITLE
Bump actions/checkout v4 -> v5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Homebrew
         run: |

--- a/.github/workflows/update-cask.yml
+++ b/.github/workflows/update-cask.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Check for updates
         id: check


### PR DESCRIPTION
## Why

GitHub Actions now emits a deprecation annotation on every run:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/checkout@v4`.

`actions/checkout@v5` runs natively on Node 24, clearing the warning.

## Changes

Bump `actions/checkout@v4` → `@v5` in both workflows:
- `.github/workflows/test.yml`
- `.github/workflows/update-cask.yml`

No behavior change — checkout usage is unchanged, this only moves off the deprecated Node 20 runtime.