### PR TITLE
Loosen livecheck regex to tolerate compiler-name changes

### DIFF
--- a/Casks/kdeconnect.rb
+++ b/Casks/kdeconnect.rb
@@ -15,7 +15,7 @@ cask "kdeconnect" do
 
   livecheck do
     url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-arm64/"
-    regex(/kdeconnect-kde-master-(\d+)-macos-clang-arm64\.dmg/)
+    regex(/kdeconnect-kde-master-(\d+)-macos.*?arm64\.dmg/i)
     strategy :page_match
   end
 


### PR DESCRIPTION
## Why

The livecheck regex hardcoded `clang`:

```
/kdeconnect-kde-master-(\d+)-macos-clang-arm64\.dmg/
```

`clang` is an incidental build detail. If KDE's CI renames it (`clang19`, a different toolchain) or drops the segment, the regex stops matching and `brew livecheck` (plus the CI "Test livecheck" assertion) silently reports no new version.

Note: the daily auto-update workflow does **not** rely on this regex — it greps the directory listing itself — so update delivery was never at risk. This only hardens `brew livecheck` reporting and the CI check.

## Change

```diff
-    regex(/kdeconnect-kde-master-(\d+)-macos-clang-arm64\.dmg/)
+    regex(/kdeconnect-kde-master-(\d+)-macos.*?arm64\.dmg/i)
```

Keeps the `kdeconnect-kde-master-`, `-macos`, and `arm64\.dmg` anchors, so x86_64 and unrelated files still don't match, while tolerating whatever compiler token sits in the middle.

## Verification

Tested against the current filename and hypothetical variants:

| filename | old | new |
|---|---|---|
| `...-6325-macos-clang-arm64.dmg` (current) | ✅ 6325 | ✅ 6325 |
| `...-6400-macos-arm64.dmg` (clang dropped) | ❌ | ✅ 6400 |
| `...-6400-macos-clang19-arm64.dmg` | ❌ | ✅ 6400 |
| `...-6400-macos-gcc-arm64.dmg` | ❌ | ✅ 6400 |
| `...-6400-macos-clang-x86_64.dmg` (x86) | ❌ | ❌ (correct) |

`brew style Casks/kdeconnect.rb` → no offenses.