### PR TITLE
Track each arch's build independently

### DIFF
--- a/.github/workflows/update-cask.yml
+++ b/.github/workflows/update-cask.yml
@@ -17,51 +17,67 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Determine latest build
+      - name: Determine latest builds
         id: check
         run: |
           base="https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master"
 
           # Each arch directory retains only its latest build; pull the build number
           # out of the DMG filename (anchored + numeric sort, not lexical).
-          arm=$(curl -fsSL "$base/macos-arm64/"   | grep -oE 'kdeconnect-kde-master-[0-9]+-macos[^"<> ]*arm64\.dmg'  | grep -oE 'master-[0-9]+' | grep -oE '[0-9]+' | sort -n | tail -1)
-          intel=$(curl -fsSL "$base/macos-x86_64/" | grep -oE 'kdeconnect-kde-master-[0-9]+-macos[^"<> ]*x86_64\.dmg' | grep -oE 'master-[0-9]+' | grep -oE '[0-9]+' | sort -n | tail -1)
-          current=$(grep -oE 'version "[0-9]+"' Casks/kdeconnect.rb | grep -oE '[0-9]+')
-          echo "arm64=$arm  x86_64=$intel  current=$current"
+          arm_latest=$(curl -fsSL "$base/macos-arm64/"   | grep -oE 'kdeconnect-kde-master-[0-9]+-macos[^"<> ]*arm64\.dmg'  | grep -oE 'master-[0-9]+' | grep -oE '[0-9]+' | sort -n | tail -1)
+          intel_latest=$(curl -fsSL "$base/macos-x86_64/" | grep -oE 'kdeconnect-kde-master-[0-9]+-macos[^"<> ]*x86_64\.dmg' | grep -oE 'master-[0-9]+' | grep -oE '[0-9]+' | sort -n | tail -1)
 
-          if [ -z "$arm" ] || [ -z "$intel" ]; then
-            echo "Could not determine build numbers; skipping."
-            echo "update_needed=false" >> "$GITHUB_OUTPUT"
-          elif [ "$arm" != "$intel" ]; then
-            # Both arch URLs interpolate a single #{version}; a shared build must exist
-            # on both. During the brief publish skew the older build is already gone,
-            # so wait for the next run rather than pin a version one arch can't serve.
-            echo "Arch build skew (arm64=$arm, x86_64=$intel); waiting for convergence."
-            echo "update_needed=false" >> "$GITHUB_OUTPUT"
-          elif [ "$arm" = "$current" ]; then
-            echo "Already up to date ($current)."
+          # Read each arch's current version from its on_arm/on_intel block.
+          arm_current=$(awk '/on_arm do/{f=1} /on_intel do/{f=0} f&&/version "/{gsub(/[^0-9]/,"");print;exit}' Casks/kdeconnect.rb)
+          intel_current=$(awk '/on_intel do/{f=1} f&&/version "/{gsub(/[^0-9]/,"");print;exit}' Casks/kdeconnect.rb)
+          echo "arm64:  current=$arm_current  latest=$arm_latest"
+          echo "x86_64: current=$intel_current latest=$intel_latest"
+
+          # Bump each arch independently: whichever has a newer build gets updated,
+          # so a publish skew between arches never stalls (or 404s) the other.
+          bump_arm=""; bump_intel=""; changes=""
+          if [ -n "$arm_latest" ] && [ "$arm_latest" != "$arm_current" ]; then
+            bump_arm="$arm_latest"; changes="arm64 $arm_current→$arm_latest"
+          fi
+          if [ -n "$intel_latest" ] && [ "$intel_latest" != "$intel_current" ]; then
+            bump_intel="$intel_latest"; changes="${changes:+$changes, }x86_64 $intel_current→$intel_latest"
+          fi
+
+          if [ -z "$bump_arm" ] && [ -z "$bump_intel" ]; then
+            echo "Already up to date."
             echo "update_needed=false" >> "$GITHUB_OUTPUT"
           else
-            echo "New version available: $arm"
-            echo "new_version=$arm" >> "$GITHUB_OUTPUT"
-            echo "update_needed=true" >> "$GITHUB_OUTPUT"
+            # Newer of the two builds labels the branch and PR title.
+            display=$(printf '%s\n%s\n' "$arm_latest" "$intel_latest" | sort -n | tail -1)
+            echo "Update: $changes"
+            {
+              echo "update_needed=true"
+              echo "bump_arm=$bump_arm"
+              echo "bump_intel=$bump_intel"
+              echo "display=$display"
+              echo "changes=$changes"
+            } >> "$GITHUB_OUTPUT"
           fi
 
       - name: Bump cask (download DMGs, compute checksums)
         if: steps.check.outputs.update_needed == 'true'
         env:
-          NEW_VERSION: ${{ steps.check.outputs.new_version }}
+          BUMP_ARM: ${{ steps.check.outputs.bump_arm }}
+          BUMP_INTEL: ${{ steps.check.outputs.bump_intel }}
         run: |
           # brew bump-cask-pr needs the cask inside a tap; use the checkout as the tap.
           TAP="$(brew --repo)/Library/Taps/imshuhao/homebrew-kdeconnect"
           mkdir -p "$(dirname "$TAP")"
           cp -R "$GITHUB_WORKSPACE" "$TAP"
 
-          # --write-only downloads both arch DMGs, computes both SHA-256s, and rewrites
-          # the cask in place without any git action. Failure here (e.g. a missing DMG)
-          # aborts the run, so a broken build never reaches a PR.
+          # Update only the arch(es) that changed. --write-only downloads each DMG,
+          # computes its SHA-256, and rewrites the cask without any git action; a
+          # missing/corrupt DMG aborts the run so a broken build never reaches a PR.
+          flags=()
+          [ -n "$BUMP_ARM" ]   && flags+=(--version-arm="$BUMP_ARM")
+          [ -n "$BUMP_INTEL" ] && flags+=(--version-intel="$BUMP_INTEL")
           brew bump-cask-pr \
-            --version="$NEW_VERSION" \
+            "${flags[@]}" \
             --write-only --no-audit --no-style --no-browse \
             imshuhao/kdeconnect/kdeconnect
 
@@ -73,20 +89,21 @@ jobs:
         if: steps.check.outputs.update_needed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
-          NEW_VERSION: ${{ steps.check.outputs.new_version }}
+          DISPLAY_VERSION: ${{ steps.check.outputs.display }}
+          CHANGES: ${{ steps.check.outputs.changes }}
         run: |
           git config user.name "GitHub Action"
           git config user.email "action@github.com"
 
-          BRANCH="update-kdeconnect-$NEW_VERSION"
+          BRANCH="update-kdeconnect-$DISPLAY_VERSION"
           git checkout -b "$BRANCH"
           git add Casks/kdeconnect.rb
-          git commit -m "Update KDE Connect to version $NEW_VERSION"
+          git commit -m "Update KDE Connect to version $DISPLAY_VERSION"
           git push -f origin "$BRANCH"
 
           PR_URL=$(gh pr create \
-            --title "Update KDE Connect to version $NEW_VERSION" \
-            --body "Automated update to version $NEW_VERSION. Both arch DMGs were downloaded and their SHA-256 checksums verified by \`brew bump-cask-pr\`." \
+            --title "Update KDE Connect to version $DISPLAY_VERSION" \
+            --body "Automated update ($CHANGES). Each changed arch's DMG was downloaded and its SHA-256 verified by \`brew bump-cask-pr\`." \
             --head "$BRANCH" --base main)
           echo "Created PR: $PR_URL"
 

--- a/Casks/kdeconnect.rb
+++ b/Casks/kdeconnect.rb
@@ -1,12 +1,15 @@
 cask "kdeconnect" do
-  version "6325"
-
+  # Each arch tracks its own build: KDE's CI retains only the latest DMG per
+  # arch and the two can publish a few minutes apart, so a single shared
+  # version would 404 for the lagging arch during that window.
   on_arm do
+    version "6325"
     sha256 "7f908b07fa4ff005d276b2fdae7f24b7c3b7a1d26daa6f1b5e1a55b9d6ae29e1"
 
     url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-arm64/kdeconnect-kde-master-#{version}-macos-clang-arm64.dmg"
   end
   on_intel do
+    version "6325"
     sha256 "ae85dd5c14f703c85f3fb06b8510570d9df22c0bfa05d1bf893caab5e3040479"
 
     url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-x86_64/kdeconnect-kde-master-#{version}-macos-clang-x86_64.dmg"


### PR DESCRIPTION
## Problem

The updater previously required arm64 and x86_64 to be at the **same** build, skipping otherwise. But KDE's CI keeps only the *latest* DMG per arch, and the two arches publish a few minutes apart — so during that skew there is no common build to pin (a shared `#{version}` would 404 for the lagging arch). Worse, if one arch's builds lagged for a while, the cask would get **stuck with no updates at all**.

## Fix: per-arch versions

`version` moves into each `on_arm` / `on_intel` block, so the arches can sit at different builds:

```diff
-  version "6325"
-
   on_arm do
+    version "6325"
     sha256 "7f908b07…"
     url "…-macos-clang-arm64.dmg"
   end
   on_intel do
+    version "6325"
     sha256 "ae85dd5c…"
     url "…-macos-clang-x86_64.dmg"
   end
```

The updater now bumps **each arch independently**:

- Reads each block's current version; compares to that arch's latest CDN build.
- Runs `brew bump-cask-pr --version-arm=… --version-intel=…` for **whichever changed** (downloading only the changed DMG and verifying its SHA-256).
- The newer of the two builds labels the branch/PR; the body records exactly what moved (e.g. "arm64 6325→6330").

A publish skew now just updates the ahead arch and picks up the other next run — it never stalls or 404s.

## Verification

- **Per-arch cask** → `brew style` clean.
- **`bump-cask-pr --version-arm=6325 --write-only`** on a test cask → updated only the arm block (version + real sha256), left intel at its old value untouched.
- **Decision logic** simulated across 6 scenarios (both-current, both-bump, arm-only, intel-only, convergence, both-at-different-builds) — all correct.
- `actionlint` + `shellcheck` pass.

Both arches are at 6325 today, so this PR is a no-op for users — it just enables correct behavior when the arches diverge.