### PR TITLE
Make livecheck arch-aware

### DIFF
--- a/Casks/kdeconnect.rb
+++ b/Casks/kdeconnect.rb
@@ -1,4 +1,6 @@
 cask "kdeconnect" do
+  arch arm: "arm64", intel: "x86_64"
+
   # Each arch tracks its own build: KDE's CI retains only the latest DMG per
   # arch and the two can publish a few minutes apart, so a single shared
   # version would 404 for the lagging arch during that window.
@@ -20,8 +22,8 @@ cask "kdeconnect" do
   homepage "https://kdeconnect.kde.org/"
 
   livecheck do
-    url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-arm64/"
-    regex(/kdeconnect-kde-master-(\d+)-macos.*?arm64\.dmg/i)
+    url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-#{arch}/"
+    regex(/kdeconnect-kde-master-(\d+)-macos.*?#{arch}\.dmg/i)
     strategy :page_match
   end
 


### PR DESCRIPTION
## Why

We just moved `version` into the `on_arm`/`on_intel` blocks so each arch tracks its own build. But `livecheck` still hardcoded the **arm64** directory:

```ruby
livecheck do
  url ".../macos-arm64/"
  regex(/…-macos.*?arm64\.dmg/i)
end
```

So an Intel machine running `brew livecheck` compared its **x86_64** installed version against the **arm64** latest build — misleading the moment the two arches diverge.

## Change

Add an `arch` stanza and interpolate `#{arch}` so livecheck follows the host arch:

```diff
+  arch arm: "arm64", intel: "x86_64"
   …
   livecheck do
-    url ".../macos-arm64/"
-    regex(/…-macos.*?arm64\.dmg/i)
+    url ".../macos-#{arch}/"
+    regex(/…-macos.*?#{arch}\.dmg/i)
     strategy :page_match
   end
```

The download URLs are left untouched (their per-arch form is what `brew bump-cask-pr` maintains).

## Verification

- `brew style` clean.
- `brew livecheck --debug` on arm resolves the URL to `.../macos-arm64/` and the regex to `…arm64\.dmg`; on Intel it would resolve to `macos-x86_64` / `x86_64\.dmg`.
- `brew livecheck` reports `6325 ==> 6325`; `--json` gives `current=6325, latest=6325, outdated=false` — the shape the CI "Test livecheck" step asserts.