### PR TITLE
Update KDE Connect to version 6435

### DIFF
--- a/Casks/kdeconnect.rb
+++ b/Casks/kdeconnect.rb
@@ -5,14 +5,14 @@ cask "kdeconnect" do
   # arch and the two can publish a few minutes apart, so a single shared
   # version would 404 for the lagging arch during that window.
   on_arm do
-    version "6423"
-    sha256 "6e5e48b22e5df813aa3d87d2a74ac74ad234b85154702d430a27257770532b6d"
+    version "6435"
+    sha256 "f6694a445d8219f42459c37353e9898459b02722451412acd905fb936a282a7c"
 
     url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-arm64/kdeconnect-kde-master-#{version}-macos-clang-arm64.dmg"
   end
   on_intel do
-    version "6423"
-    sha256 "0e02b320554fdf53371a4fc0ad66abb01719a5b925128bd435e0966edf628e40"
+    version "6435"
+    sha256 "02e8e2b0961388f86feaab1221627205afedba3bf9a7a36b742cd7449331ec40"
 
     url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-x86_64/kdeconnect-kde-master-#{version}-macos-clang-x86_64.dmg"
   end


### PR DESCRIPTION
Automated update (arm64 ��6435, x86_64 ��6435). Each changed arch's DMG was downloaded and its SHA-256 verified by `brew bump-cask-pr`.