### PR TITLE
Update KDE Connect to version 6444

### DIFF
--- a/Casks/kdeconnect.rb
+++ b/Casks/kdeconnect.rb
@@ -5,14 +5,14 @@ cask "kdeconnect" do
   # arch and the two can publish a few minutes apart, so a single shared
   # version would 404 for the lagging arch during that window.
   on_arm do
-    version "6435"
-    sha256 "f6694a445d8219f42459c37353e9898459b02722451412acd905fb936a282a7c"
+    version "6444"
+    sha256 "8d6badb35bb4c56a2f00f5bedc1768cdf0a6c693e5ee7d67ef48306abfe86d4f"
 
     url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-arm64/kdeconnect-kde-master-#{version}-macos-clang-arm64.dmg"
   end
   on_intel do
-    version "6435"
-    sha256 "02e8e2b0961388f86feaab1221627205afedba3bf9a7a36b742cd7449331ec40"
+    version "6444"
+    sha256 "25afcc44a84c2f1b82442be0b3a279a847e61876638172743d3e5fb7c2e8ee76"
 
     url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-x86_64/kdeconnect-kde-master-#{version}-macos-clang-x86_64.dmg"
   end


### PR DESCRIPTION
Automated update (arm64 ��6444, x86_64 ��6444). Each changed arch's DMG was downloaded and its SHA-256 verified by `brew bump-cask-pr`.