### PR TITLE
Update KDE Connect to version 6453

### DIFF
--- a/Casks/kdeconnect.rb
+++ b/Casks/kdeconnect.rb
@@ -5,14 +5,14 @@ cask "kdeconnect" do
   # arch and the two can publish a few minutes apart, so a single shared
   # version would 404 for the lagging arch during that window.
   on_arm do
-    version "6444"
-    sha256 "8d6badb35bb4c56a2f00f5bedc1768cdf0a6c693e5ee7d67ef48306abfe86d4f"
+    version "6453"
+    sha256 "d4f532b6dbad0c58a842a3352e75d0f734a3b6a330431da01fbc7e4225e83231"
 
     url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-arm64/kdeconnect-kde-master-#{version}-macos-clang-arm64.dmg"
   end
   on_intel do
-    version "6444"
-    sha256 "25afcc44a84c2f1b82442be0b3a279a847e61876638172743d3e5fb7c2e8ee76"
+    version "6453"
+    sha256 "5bf65951d2909c1a088ea3eb8e63535a41ae706b317906e2e096811c09ce8c6d"
 
     url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-x86_64/kdeconnect-kde-master-#{version}-macos-clang-x86_64.dmg"
   end


### PR DESCRIPTION
Automated update (arm64 ��6453, x86_64 ��6453). Each changed arch's DMG was downloaded and its SHA-256 verified by `brew bump-cask-pr`.