### PR TITLE
Update KDE Connect to version 6469

### DIFF
--- a/Casks/kdeconnect.rb
+++ b/Casks/kdeconnect.rb
@@ -5,14 +5,14 @@ cask "kdeconnect" do
   # arch and the two can publish a few minutes apart, so a single shared
   # version would 404 for the lagging arch during that window.
   on_arm do
-    version "6465"
-    sha256 "ec2d1e9514728b7b571200655fea5114b9951438c0144c00f4ee727ebba753ac"
+    version "6469"
+    sha256 "071b020a2357e0984c9c8f949ed66003d36aed1b5c5bec5c21486f1871d777e6"
 
     url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-arm64/kdeconnect-kde-master-#{version}-macos-clang-arm64.dmg"
   end
   on_intel do
-    version "6465"
-    sha256 "c249124565a52aba26612daad3129e5f8e264b1ee51404638253dfeb2aed93a7"
+    version "6469"
+    sha256 "4f4dfa1f9e44440ce690291429621aed0ba0d86f3db09f07eea2979127805738"
 
     url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-x86_64/kdeconnect-kde-master-#{version}-macos-clang-x86_64.dmg"
   end


### PR DESCRIPTION
Automated update (arm64 ��6469, x86_64 ��6469). Each changed arch's DMG was downloaded and its SHA-256 verified by `brew bump-cask-pr`.