### PR TITLE
Update KDE Connect to version 6495

### DIFF
--- a/Casks/kdeconnect.rb
+++ b/Casks/kdeconnect.rb
@@ -5,14 +5,14 @@ cask "kdeconnect" do
   # arch and the two can publish a few minutes apart, so a single shared
   # version would 404 for the lagging arch during that window.
   on_arm do
-    version "6486"
-    sha256 "5d2e4d4d928722be7074c50bf9a3b64499e80abf77558b392625588378714ed6"
+    version "6495"
+    sha256 "37a701bf8b51e7470756e1c75d89232489d5c234fe4a4976688c32a2068eadf9"
 
     url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-arm64/kdeconnect-kde-master-#{version}-macos-clang-arm64.dmg"
   end
   on_intel do
-    version "6486"
-    sha256 "d8972f41513b9ea70079dae554bfafc4093fa340609012e2c2c490be0ece787e"
+    version "6495"
+    sha256 "964d8799f6d3ed13bcd7f40c3a73322156ac307b967afe5876fe90d0fcf56378"
 
     url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-x86_64/kdeconnect-kde-master-#{version}-macos-clang-x86_64.dmg"
   end


### PR DESCRIPTION
Automated update (arm64 ��6495, x86_64 ��6495). Each changed arch's DMG was downloaded and its SHA-256 verified by `brew bump-cask-pr`.