### PR TITLE
Update KDE Connect to version 6510

### DIFF
--- a/Casks/kdeconnect.rb
+++ b/Casks/kdeconnect.rb
@@ -5,14 +5,14 @@ cask "kdeconnect" do
   # arch and the two can publish a few minutes apart, so a single shared
   # version would 404 for the lagging arch during that window.
   on_arm do
-    version "6495"
-    sha256 "37a701bf8b51e7470756e1c75d89232489d5c234fe4a4976688c32a2068eadf9"
+    version "6510"
+    sha256 "77ef9d6f38e65b24654584181b06d42a23201643358d2c0c2e8dde2524aaa41f"
 
     url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-arm64/kdeconnect-kde-master-#{version}-macos-clang-arm64.dmg"
   end
   on_intel do
-    version "6495"
-    sha256 "964d8799f6d3ed13bcd7f40c3a73322156ac307b967afe5876fe90d0fcf56378"
+    version "6510"
+    sha256 "5671f75e069ab74b15c20649600a959f74ee007ae78b3b35c91b0baaf0991d38"
 
     url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-x86_64/kdeconnect-kde-master-#{version}-macos-clang-x86_64.dmg"
   end


### PR DESCRIPTION
Automated update (arm64 ��6510, x86_64 ��6510). Each changed arch's DMG was downloaded and its SHA-256 verified by `brew bump-cask-pr`.