### PR TITLE
Update KDE Connect to version 6518

### DIFF
--- a/Casks/kdeconnect.rb
+++ b/Casks/kdeconnect.rb
@@ -5,14 +5,14 @@ cask "kdeconnect" do
   # arch and the two can publish a few minutes apart, so a single shared
   # version would 404 for the lagging arch during that window.
   on_arm do
-    version "6510"
-    sha256 "77ef9d6f38e65b24654584181b06d42a23201643358d2c0c2e8dde2524aaa41f"
+    version "6518"
+    sha256 "3077a5e0b0f870e5ac66df93aac66db5ef812c285779dd58924e6b7b4150c6a7"
 
     url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-arm64/kdeconnect-kde-master-#{version}-macos-clang-arm64.dmg"
   end
   on_intel do
-    version "6510"
-    sha256 "5671f75e069ab74b15c20649600a959f74ee007ae78b3b35c91b0baaf0991d38"
+    version "6518"
+    sha256 "8e3424cdfe4031f512b5dde917fae6959f5122a84a4d79f0d4a5bca3f747e65d"
 
     url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-x86_64/kdeconnect-kde-master-#{version}-macos-clang-x86_64.dmg"
   end


### PR DESCRIPTION
Automated update (arm64 ��6518, x86_64 ��6518). Each changed arch's DMG was downloaded and its SHA-256 verified by `brew bump-cask-pr`.