### PR TITLE
Update KDE Connect to version 6533

### DIFF
--- a/Casks/kdeconnect.rb
+++ b/Casks/kdeconnect.rb
@@ -5,14 +5,14 @@ cask "kdeconnect" do
   # arch and the two can publish a few minutes apart, so a single shared
   # version would 404 for the lagging arch during that window.
   on_arm do
-    version "6530"
-    sha256 "900e9c424df6bcd59a0916d0f589346972df977b89a1f3710f4692ce54ed0312"
+    version "6533"
+    sha256 "7116f75eb9c79ea5db9e81b90b1c0ecc75570a11dffdf5b9521b53567b7d0fde"
 
     url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-arm64/kdeconnect-kde-master-#{version}-macos-clang-arm64.dmg"
   end
   on_intel do
-    version "6530"
-    sha256 "725bb1833e740337907e70171f234959e0760c94359e3bff8d8ace8da1d2519f"
+    version "6533"
+    sha256 "81193c33d7d0b0090b537468396234cbea625df1e6499b87b4968e966ad5cae9"
 
     url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-x86_64/kdeconnect-kde-master-#{version}-macos-clang-x86_64.dmg"
   end


### PR DESCRIPTION
Automated update (arm64 ��6533, x86_64 ��6533). Each changed arch's DMG was downloaded and its SHA-256 verified by `brew bump-cask-pr`.