### PR TITLE
Update KDE Connect to version 6542

### DIFF
--- a/Casks/kdeconnect.rb
+++ b/Casks/kdeconnect.rb
@@ -5,14 +5,14 @@ cask "kdeconnect" do
   # arch and the two can publish a few minutes apart, so a single shared
   # version would 404 for the lagging arch during that window.
   on_arm do
-    version "6533"
-    sha256 "7116f75eb9c79ea5db9e81b90b1c0ecc75570a11dffdf5b9521b53567b7d0fde"
+    version "6542"
+    sha256 "4e944929d97172c88ad841201991e8dfb229b14ee5a42642723e1a2d00c23e35"
 
     url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-arm64/kdeconnect-kde-master-#{version}-macos-clang-arm64.dmg"
   end
   on_intel do
-    version "6533"
-    sha256 "81193c33d7d0b0090b537468396234cbea625df1e6499b87b4968e966ad5cae9"
+    version "6542"
+    sha256 "7655dd67585ec346bf86426ecd8c428367313d1d4c92f59d396f9bf30b8ab7c3"
 
     url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-x86_64/kdeconnect-kde-master-#{version}-macos-clang-x86_64.dmg"
   end


### PR DESCRIPTION
Automated update (arm64 ��6542, x86_64 ��6542). Each changed arch's DMG was downloaded and its SHA-256 verified by `brew bump-cask-pr`.