### PR TITLE
Update KDE Connect to version 6561

### DIFF
--- a/Casks/kdeconnect.rb
+++ b/Casks/kdeconnect.rb
@@ -5,14 +5,14 @@ cask "kdeconnect" do
   # arch and the two can publish a few minutes apart, so a single shared
   # version would 404 for the lagging arch during that window.
   on_arm do
-    version "6542"
-    sha256 "4e944929d97172c88ad841201991e8dfb229b14ee5a42642723e1a2d00c23e35"
+    version "6561"
+    sha256 "127631bd054a8cab61166b8b2ade16928797dc7a9eb9d971e5784cdbe80d1e23"
 
     url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-arm64/kdeconnect-kde-master-#{version}-macos-clang-arm64.dmg"
   end
   on_intel do
-    version "6542"
-    sha256 "7655dd67585ec346bf86426ecd8c428367313d1d4c92f59d396f9bf30b8ab7c3"
+    version "6561"
+    sha256 "19f5ca14816c4101ac48e9a8fb7506d25e87e8ef1d8c3d8107d54260ef9fdf63"
 
     url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-x86_64/kdeconnect-kde-master-#{version}-macos-clang-x86_64.dmg"
   end


### PR DESCRIPTION
Automated update (arm64 ��6561, x86_64 ��6561). Each changed arch's DMG was downloaded and its SHA-256 verified by `brew bump-cask-pr`.